### PR TITLE
Fix for spinner loader using cdn

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,7 +12,7 @@
         <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.26/angular.min.js"></script>
         <script src="//code.angularjs.org/1.2.26/angular-route.min.js"></script>
         <script src="//code.angularjs.org/1.2.26/angular-route.min.js.map"></script>
-        <script src="//fgnass.github.io/spin.js/spin.min.js"></script>
+        <script src="//cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
         <script src="//d3js.org/d3.v2.min.js"></script>
         <script src="app/app.js"></script>
         <script src="app/configuration.js"></script>


### PR DESCRIPTION
### Description
* Changed CDN Link of spin.js with a specific version.

### To test
* run `python -m SimpleHTTPServer 8080` in `frontend` dir